### PR TITLE
support persistent volumes/pvc

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,0 +1,7 @@
+chart-dirs:
+  - charts/flipt
+helm-extra-args: --timeout 300s
+check-version-increment: true
+debug: true
+upgrade: true
+target-branch: main

--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,5 +1,5 @@
 chart-dirs:
-  - charts/flipt
+  - charts
 helm-extra-args: --timeout 300s
 check-version-increment: true
 debug: true

--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,7 +1,0 @@
-chart-dirs:
-  - charts
-helm-extra-args: --timeout 300s
-check-version-increment: true
-debug: true
-upgrade: true
-target-branch: main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,4 +40,4 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install
+        run: ct install --config ct.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+ct_previous*

--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,5 +3,8 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open source, self-hosted feature flag solution.
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: "v1.9.0"
+maintainers:
+  - name: Flipt
+    url: https://github.com/flipt-io/helm-charts

--- a/charts/flipt/templates/_helpers.tpl
+++ b/charts/flipt/templates/_helpers.tpl
@@ -60,3 +60,36 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "common.tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}
+
+{{/*
+Return  the proper Storage Class
+{{ include "common.storage.class" ( dict "persistence" .Values.path.to.the.persistence "global" $) }}
+*/}}
+{{- define "common.storage.class" -}}
+{{- $storageClass := .persistence.storageClass -}}
+{{- if .global -}}
+    {{- if .global.storageClass -}}
+        {{- $storageClass = .global.storageClass -}}
+    {{- end -}}
+{{- end -}}
+{{- if $storageClass -}}
+  {{- if (eq "-" $storageClass) -}}
+      {{- printf "storageClassName: \"\"" -}}
+  {{- else }}
+      {{- printf "storageClassName: %s" $storageClass -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/flipt/templates/deployment.yaml
+++ b/charts/flipt/templates/deployment.yaml
@@ -35,15 +35,20 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.flipt.httpPort }}
+              containerPort: {{ coalesce .Values.flipt.httpPort .Values.containerPorts.http }}
               protocol: TCP
             - name: grpc
-              containerPort: {{ .Values.flipt.grpcPort }}
+              containerPort: {{ coalesce .Values.flipt.grpcPort .Values.containerPorts.grpc }}
               protocol: TCP
           volumeMounts:
-            - name: config-volume
+            - name: flipt-config
               mountPath: /etc/flipt/config.yml
               readOnly: true
+            - name: flipt-data
+              mountPath: /var/opt/flipt
+            {{- if .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /
@@ -55,9 +60,16 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
-        - name: config-volume
+        - name: flipt-config
           configMap:
             name: {{ include "flipt.fullname" . }}
+        - name: flipt-data
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ default (include "flipt.fullname" .) .Values.persistence.existingClaim }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/flipt/templates/pvc.yaml
+++ b/charts/flipt/templates/pvc.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "flipt.fullname" . }}
+  labels:
+    {{- include "flipt.labels" . | nindent 4 }}
+  {{- if or .Values.persistence.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.persistence.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.persistence.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  accessModes:
+  {{- range .Values.persistence.accessModes }}
+    - {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 2 }}
+{{- end -}}

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: markphelps/flipt
+  repository: flipt/flipt
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
@@ -78,9 +78,42 @@ tolerations: []
 
 affinity: {}
 
-# Flipt deployment settings
+## Container ports
+##
+containerPorts:
+  ## http is the Flipt HTTP container port
+  http: 8080
+  ## grpc Flipt GRPC container port
+  grpc: 9000
+
+## Persistence Parameters
+## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  ## enabled enables persistence using Persistent Volume Claims
+  enabled: false
+  ## annotations are additional custom annotations for the PVC
+  annotations: {}
+  ## existingClaim sets the name of an existing PVC to use for persistence
+  existingClaim: ""
+  ## subPath is the name of a volume's sub path to mount for persistence
+  subPath: ""
+  ## accessModes [array] Persistent Volume access modes
+  accessModes:
+    - ReadWriteOnce
+  ## storageClass sets Persistent Volume storage class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner
+  ##
+  storageClass: ""
+  ## size is the Persistent Volume size
+  size: 5Gi
+
 flipt:
-  # Port to expose the http service on
+  # httpPort is the Flipt HTTP container port
+  # @deprecated use containerPorts.http instead
   httpPort: 8080
-  # Port to expose the grpc service on
+  # grpcPort is the Flipt GRPC container port
+  # @deprecated use containerPorts.grpc instead
   grpcPort: 9000

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,5 +1,5 @@
 chart-dirs:
-  - charts/flipt
+  - charts
 helm-extra-args: --timeout 300s
 check-version-increment: true
 debug: true


### PR DESCRIPTION
Should fix https://github.com/flipt-io/flipt/issues/963

- [ ] Adds support for [PVC/PV](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) to store flipt data (ie SQLite DB
- [ ] deprecates `flipt.httpPort` and `flipt.grpcPort` in favor of `containerPorts.http` and `containerPorts.grpc` respectively
- [ ] Updates image to `flipt/flipt` instead of `markphelps/flipt` (same image, just in the process of moving docker namespaces)