### PR TITLE
Fix configmap to put in correct place on pod

### DIFF
--- a/charts/flipt/templates/configmap.yaml
+++ b/charts/flipt/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "flipt.labels" . | nindent 4 }}
 data:
-  config.yml: |
+  default.yml: |
     log:
       level: WARN
 

--- a/charts/flipt/templates/deployment.yaml
+++ b/charts/flipt/templates/deployment.yaml
@@ -42,8 +42,9 @@ spec:
               protocol: TCP
           volumeMounts:
             - name: flipt-config
-              mountPath: /etc/flipt/config.yml
+              mountPath: /etc/flipt/config/default.yml
               readOnly: true
+              subPath: default.yml
             - name: flipt-data
               mountPath: /var/opt/flipt
             {{- if .Values.persistence.subPath }}


### PR DESCRIPTION
Mount the default config map in the correct place on the pod

Re: https://github.com/flipt-io/flipt/issues/1035