### PR TITLE
Bump for v0.12

### DIFF
--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,8 +3,8 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open source, self-hosted feature flag solution.
 type: application
-version: 0.11.0
-appVersion: "v1.12.0"
+version: 0.12.0
+appVersion: "v1.13.0"
 maintainers:
   - name: Flipt
     url: https://github.com/flipt-io/helm-charts


### PR DESCRIPTION
Bump chart for [latest release](https://github.com/flipt-io/flipt/releases/tag/v1.13.0) of Flipt