### PR TITLE
Fix file permissions when using security context + CockroachDB client certificates

### DIFF
--- a/charts/flipt/templates/deployment.yaml
+++ b/charts/flipt/templates/deployment.yaml
@@ -41,10 +41,14 @@ spec:
               containerPort: {{ coalesce .Values.flipt.grpcPort .Values.containerPorts.grpc }}
               protocol: TCP
           env:
+            - name: FLIPT_META_STATE_DIRECTORY
+              value: /home/flipt/.config/flipt
             {{- if .Values.flipt.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.flipt.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           volumeMounts:
+            - name: flipt-local-state
+              mountPath: /home/flipt/.config/flipt
             - name: flipt-config
               mountPath: /etc/flipt/config/default.yml
               readOnly: true
@@ -67,6 +71,8 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
+        - name: flipt-local-state
+          emptyDir: {}
         - name: flipt-config
           configMap:
             name: {{ include "flipt.fullname" . }}

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -32,6 +32,7 @@ securityContext:
     drop:
       - ALL
   privileged: false
+  readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 100
 

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -22,17 +22,18 @@ serviceAccount:
 podAnnotations: {}
 
 podSecurityContext:
-  {}
-  # fsGroup: 2000
+  runAsUser: 100
+  runAsGroup: 1000
+  fsGroup: 1000
 
 securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  privileged: false
+  runAsNonRoot: true
+  runAsUser: 100
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Hey there!

Thanks for this Helm chart, it works great! While `helm template`ing and trying to run Flipt as non-root I came across a couple issues related to file system permissions.

I'm using CockroachDB and this requires user certificates to successfully connect. I usually just put them into a `Secret` and mount them, then configure the DSN accordingly.

For reference, this is my DSN:
```
cockroach://production_flipt@cockroachdb-public.cockroachdb-system.svc.cluster.local:26257/production_flipt?sslmode=verify-full&sslcert=/etc/certificates/cockroachdb/tls.crt&sslkey=/etc/certificates/cockroachdb/tls.key&sslrootcert=/etc/certificates/cockroachdb/ca.crt
```

[I know, that's quite a lot of options for SSL 😅]

Additionally, I always want to run everything as non-root and luckily, your `Dockerfile` is already correctly configured. However, both of these together result in the Flipt binary being unable to read the certificates when mounted.

These changes fix that by:
- running as user ID 100 (flipt user)
- running as group 1000 (flipt group)
- setting the `podSecurityContext.fsGroup` to 1000 as well

Proof that these values are correct:
```
$ docker run -it --entrypoint /bin/sh flipt/flipt:v1.17.0
…
Status: Downloaded newer image for flipt/flipt:v1.17.0
/ $ whoami
flipt
/ $ id flipt
uid=100(flipt) gid=1000(flipt) groups=1000(flipt),1000(flipt)
```

I took the liberty of enabling the security contexts by default. There's no harm because like I said, your `Dockerfile` already creates a group + user and can therefore always run with the security context set.

I also activated `securityContext.readOnlyRootFilesystem` but this required one additional small change because Flipt stores local state for Telemetry and the like. I added an empty dir volume for that. If you don't want that, I can drop 09ff22133890e61580b7625fe0c6dfe5d5455943.

So awesome to see that everyone is moving towards non-root containers. 🎉

To test this, I did a `helm template` using the local Helm chart from my git clone and deployed that.