### PR TITLE
feat: add workflow to auto-update chart to latest Flipt release

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,5 +1,4 @@
 on:
-  push:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,4 +1,5 @@
 on:
+  push:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,48 @@
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: Update Chart Versions
+jobs:
+  update-chart-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Fetch Latest Flipt Release Tag
+        id: fetch_tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag=$(gh release view -R flipt-io/flipt --json tagName | jq -r .tagName)
+          echo "tag=${tag}" >> $GITHUB_OUTPUT
+     
+      - name: Update Chart Versions
+        id: update_chart
+        run: |
+          tag="${{ steps.fetch_tag.outputs.tag }}"
+          # set current app version
+          yq e ".appVersion = \"${tag}\"" charts/flipt/Chart.yaml
+          # bump current chart MINOR version
+          yq e '.version' charts/flipt/Chart.yaml | awk -F. '{ print $1,$2+1,$3 }' OFS=. | xargs -I{} yq e '.version = "{}"' -i charts/flipt/Chart.yaml
+
+      - name: Open PR
+        env:
+          GIT_AUTHOR_NAME: flipt-bot
+          GIT_AUTHOR_EMAIL: dev@flipt.io
+          GIT_COMMITTER_NAME: flipt-bot
+          GIT_COMMITTER_EMAIL: dev@flipt.io
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${{ steps.fetch_tag.outputs.tag }}"
+          git checkout -b "update/${tag}"
+          git add charts/flipt/Chart.yaml
+          git commit -m "feat: update Flipt version to release ${tag}"
+          git push origin "update/${tag}"
+          gh pr create --title "feat: update Flipt version to release ${tag}" \
+            --body "Updating chart to Flipt release [${tag}](https://github.com/flipt-io/flipt/releases/tag/${tag})."
+


### PR DESCRIPTION
Fixes: FLI-102

This is a workflow which when triggered bumps the Flipt `appVersion` in the chart YAML to the latest release version.
It also does a `MINOR` bump for the helm chart itself.