### PR TITLE
perf: allow yaml config format

### DIFF
--- a/charts/flipt/templates/configmap.yaml
+++ b/charts/flipt/templates/configmap.yaml
@@ -6,11 +6,4 @@ metadata:
     {{- include "flipt.labels" . | nindent 4 }}
 data:
   default.yml: |
-    log:
-      level: WARN
-
-    server:
-      protocol: http
-      host: 0.0.0.0
-      http_port: 8080
-      grpc_port: 9000
+    {{ toYaml .Values.flipt | nindent 4 }}

--- a/charts/flipt/templates/deployment.yaml
+++ b/charts/flipt/templates/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "flipt.fullname" . }}
   labels:
     {{- include "flipt.labels" . | nindent 4 }}
+  annotations:
+    checksum/config: {{ join "," .Values.flipt | sha256sum }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -35,16 +37,16 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ coalesce .Values.flipt.httpPort .Values.containerPorts.http }}
+              containerPort: {{ .Values.flipt.server.http_port }}
               protocol: TCP
             - name: grpc
-              containerPort: {{ coalesce .Values.flipt.grpcPort .Values.containerPorts.grpc }}
+              containerPort: {{ .Values.flipt.server.grpc_port }}
               protocol: TCP
           env:
             - name: FLIPT_META_STATE_DIRECTORY
               value: /home/flipt/.config/flipt
-            {{- if .Values.flipt.extraEnvVars }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.flipt.extraEnvVars "context" $) | nindent 12 }}
+            {{- if .Values.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           volumeMounts:
             - name: flipt-local-state

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -40,12 +40,15 @@ service:
   type: ClusterIP
   httpPort: 8080
   grpcPort: 9000
+  annotations: {}
+    # prometheus.io/scrape: "true"
+    # prometheus.io/path: "/metrics"
+    # prometheus.io/port: "8080"
 
 ingress:
   enabled: false
   className: ""
-  annotations:
-    {}
+  annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
@@ -58,8 +61,7 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources:
-  {}
+resources: {}
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -70,23 +72,13 @@ resources:
 autoscaling:
   enabled: false
   minReplicas: 1
-  maxReplicas: 100
+  maxReplicas: 5
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
 nodeSelector: {}
-
 tolerations: []
-
 affinity: {}
-
-## Container ports
-##
-containerPorts:
-  ## http is the Flipt HTTP container port
-  http: 8080
-  ## grpc Flipt GRPC container port
-  grpc: 9000
 
 ## Persistence Parameters
 ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
@@ -113,13 +105,49 @@ persistence:
   size: 5Gi
 
 flipt:
-  # httpPort is the Flipt HTTP container port
-  # @deprecated use containerPorts.http instead
-  httpPort: 8080
-  # grpcPort is the Flipt GRPC container port
-  # @deprecated use containerPorts.grpc instead
-  grpcPort: 9000
-  # extraEnvVars is a list of extra environment variables to set e.g.
-  # - name: FLIPT_LOG_LEVEL
-  #   value: debug
-  extraEnvVars: []
+  log:
+    level: INFO
+    encoding: console
+    grpc_level: ERROR
+
+  ui:
+    enabled: true
+
+  cors:
+    enabled: true
+    allowed_origins: "*"
+
+  cache:
+    enabled: false
+    backend: memory
+    ttl: 60s
+    redis:
+      host: localhost
+      port: 6379
+    memory:
+      eviction_interval: 5m # Evict Expired Items Every 5m
+
+  server:
+    protocol: http
+    host: 0.0.0.0
+    https_port: 443
+    http_port: 8080
+    grpc_port: 9000
+
+  db:
+    url: file:/var/opt/flipt/flipt.db
+    max_idle_conn: 2
+    max_open_conn: 0 # unlimited
+    conn_max_lifetime: 0 # unlimited
+
+  tracing:
+    enabled: false
+    exporter: jaeger
+    jaeger:
+      host: localhost
+      port: 6831
+
+# extraEnvVars is a list of extra environment variables to set e.g.
+# - name: FLIPT_LOG_LEVEL
+#   value: debug
+extraEnvVars: []


### PR DESCRIPTION
## Description

Currently the configuration needs to be set using env variables which is very tedious.
This PR allows for the same specs as in the `yaml`-file