### PR TITLE
feat: add servicemonitor resource for Prometheus Operator scraping

### DIFF
--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open source, self-hosted feature flag solution.
 type: application
-version: 0.25.1
+version: 0.25.2
 appVersion: v1.19.1
 maintainers:
   - name: Flipt

--- a/charts/flipt/templates/servicemonitor.yaml
+++ b/charts/flipt/templates/servicemonitor.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "flipt.fullname" . }}
+  {{- with .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  labels:
+    {{- include "flipt.labels" . | nindent 4 }}
+spec:
+  endpoints:
+    - port: {{ .Values.metrics.serviceMonitor.port | quote }}
+      {{- with .Values.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      path: /metrics
+      {{- with .Values.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "flipt.labels" . | nindent 6 }}
+{{- end }}

--- a/charts/flipt/templates/servicemonitor.yaml
+++ b/charts/flipt/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.metrics.serviceMonitor.enabled }}
+{{- if ((.Values.metrics).serviceMonitor).enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -165,3 +165,29 @@ flipt:
       jaeger:
         host: localhost
         port: 6831
+
+metrics:
+  serviceMonitor:
+    # -- If enabled, ServiceMonitor resources for Prometheus Operator are created
+    enabled: false 
+    # -- Port where to scrape metrics from
+    port: 8080
+    # -- Namespace selector for ServiceMonitor resources
+    namespaceSelector: {}
+    # -- ServiceMonitor annotations
+    annotations: {}
+    # -- Additional ServiceMonitor labels
+    labels: {}
+    # -- ServiceMonitor scrape interval
+    # Default is 15s because included recording rules use a 1m rate, and scrape interval needs to be at
+    # least 1/4 rate interval.
+    interval: 15s
+    # -- ServiceMonitor scrape timeout in Go duration format (e.g. 15s)
+    scrapeTimeout: null
+    # -- ServiceMonitor relabel configs to apply to samples before scraping
+    # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+    relabelings: []
+    # -- ServiceMonitor will use http by default, but you can pick https as well
+    scheme: http
+    # -- ServiceMonitor will use these tlsConfig settings to make the health check requests
+    tlsConfig: null

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -169,7 +169,7 @@ flipt:
 metrics:
   serviceMonitor:
     # -- If enabled, ServiceMonitor resources for Prometheus Operator are created
-    enabled: false 
+    enabled: false
     # -- Port where to scrape metrics from
     port: 8080
     # -- Namespace selector for ServiceMonitor resources


### PR DESCRIPTION
## Description

This resource allows the Prometheus Operator to pick this service up for metrics scraping.

Maybe `{{- if and ($.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") .enabled }}` can be included to only install when the CRD is included? Some charts like for example Loki does this, but others like ArgoCD don't. So... idk 🤷 
