### PR TITLE
fix: svc monitor port

### DIFF
--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open source, self-hosted feature flag solution.
 type: application
-version: 0.25.2
+version: 0.25.3
 appVersion: v1.19.1
 maintainers:
   - name: Flipt

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -171,7 +171,7 @@ metrics:
     # -- If enabled, ServiceMonitor resources for Prometheus Operator are created
     enabled: false
     # -- Port where to scrape metrics from
-    port: 8080
+    port: http 
     # -- Namespace selector for ServiceMonitor resources
     namespaceSelector: {}
     # -- ServiceMonitor annotations

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -171,7 +171,7 @@ metrics:
     # -- If enabled, ServiceMonitor resources for Prometheus Operator are created
     enabled: false
     # -- Port where to scrape metrics from
-    port: http 
+    port: http
     # -- Namespace selector for ServiceMonitor resources
     namespaceSelector: {}
     # -- ServiceMonitor annotations


### PR DESCRIPTION
## Description

Made a mistake in my previous PR, the port should not be a number but the name of the http port in the svc `http`.

So apologies about the extra PR, but better this than to leave something broken right.