### PR TITLE
perf: update hpa version

### DIFF
--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,8 +3,8 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open source, self-hosted feature flag solution.
 type: application
-version: 0.29.0
-appVersion: v1.19.3
+version: 0.29.2
+appVersion: v1.20.0
 maintainers:
   - name: Flipt
     url: https://github.com/flipt-io/helm-charts

--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open source, self-hosted feature flag solution.
 type: application
-version: 0.28.1
+version: 0.29.0
 appVersion: v1.19.3
 maintainers:
   - name: Flipt

--- a/charts/flipt/templates/_helpers.tpl
+++ b/charts/flipt/templates/_helpers.tpl
@@ -97,9 +97,9 @@ Return  the proper Storage Class
 {{/*
 Pod annotations 
 */}}
-{{- define "common.classes.podAnnotations" }}
+{{- define "common.classes.podAnnotations" -}}
   {{- if .Values.podAnnotations -}}
     {{- tpl (toYaml .Values.podAnnotations) . | nindent 0 -}}
   {{- end -}}
-  {{- printf "checksum/config: %v" (join "," .Values.flipt | sha256sum) -}}
+  {{- printf "checksum/config: %v" (join "," .Values.flipt | sha256sum) | nindent 0 -}}
 {{- end -}}

--- a/charts/flipt/templates/_helpers.tpl
+++ b/charts/flipt/templates/_helpers.tpl
@@ -103,3 +103,19 @@ Pod annotations
   {{- end -}}
   {{- printf "checksum/config: %v" (join "," .Values.flipt | sha256sum) | nindent 0 -}}
 {{- end -}}
+
+{{/* Return the target Kubernetes version */}}
+{{- define "flipt.tools.kubeVersion" -}}
+{{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride }}
+{{- end }}
+
+{{/* Return the appropriate apiVersion for autoscaling */}}
+{{- define "flipt.apiVersion.autoscaling" -}}
+{{- if (.Values.apiVersionOverrides).autoscaling -}}
+{{- print .Values.apiVersionOverrides.autoscaling -}}
+{{- else if semverCompare "<1.23-0" (include "flipt.tools.kubeVersion" .) -}}
+{{- print "autoscaling/v2beta1" -}}
+{{- else -}}
+{{- print "autoscaling/v2" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/flipt/templates/hpa.yaml
+++ b/charts/flipt/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2
+apiVersion: {{ include "flipt.apiVersion.autoscaling" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "flipt.fullname" . }}
@@ -17,16 +17,24 @@ spec:
     - type: Resource
       resource:
         name: cpu
+        {{- if eq (include "flipt.apiVersion.autoscaling" $) "autoscaling/v2beta1" }}
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- else }}
         target:
           type: Utilization 
           averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- end  }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
+        {{- if eq (include "flipt.apiVersion.autoscaling" $) "autoscaling/v2beta1" }}
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- else }}
         target:
           type: Utilization 
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- end  }}
     {{- end }}
 {{- end }}

--- a/charts/flipt/templates/hpa.yaml
+++ b/charts/flipt/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "flipt.fullname" . }}
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization 
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization 
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

Since k8s v1.25 hpa/v2beta1 is no longer available. This PR updates it to v2, which has been available since k8s v1.23 [docs](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v125)

Target syntax has been changed a bit as well. [docs](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics)


Also included a small fix to get the `podAnnotations` to work again.