### PR TITLE
fix(github): use generated token instead of default

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -30,13 +30,21 @@ jobs:
           # bump current chart MINOR version
           yq e '.version' charts/flipt/Chart.yaml | awk -F. '{ print $1,$2+1,$3 }' OFS=. | xargs -I{} yq e '.version = "{}"' -i charts/flipt/Chart.yaml
 
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.FLIPT_RELEASE_BOT_APP_ID }}
+          private_key: ${{ secrets.FLIPT_RELEASE_BOT_APP_PEM }}
+          installation_id: ${{ secrets.FLIPT_RELEASE_BOT_INSTALLATION_ID }}
+
       - name: Open PR
         env:
           GIT_AUTHOR_NAME: flipt-bot
           GIT_AUTHOR_EMAIL: dev@flipt.io
           GIT_COMMITTER_NAME: flipt-bot
           GIT_COMMITTER_EMAIL: dev@flipt.io
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           tag="${{ steps.fetch_tag.outputs.tag }}"
           git checkout -b "update/${tag}"


### PR DESCRIPTION
This should fix our issue where CI does not run on the generated PRs.