### PR TITLE
Add Migration job in Helm Hook

### DIFF
--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open source, self-hosted feature flag solution.
 type: application
-version: 0.35.2
+version: 0.35.3
 appVersion: v1.23.3
 maintainers:
   - name: Flipt

--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open source, self-hosted feature flag solution.
 type: application
-version: 0.35.3
+version: 0.36.0
 appVersion: v1.23.3
 maintainers:
   - name: Flipt

--- a/charts/flipt/templates/_helpers.tpl
+++ b/charts/flipt/templates/_helpers.tpl
@@ -24,6 +24,14 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Create a fully qualified name for the migration job
+*/}}
+{{- define "flipt.migration_name" -}}
+{{- include "flipt.fullname" . | trunc 53 | trimSuffix "-" }}-migration
+{{- end }}
+
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "flipt.chart" -}}
@@ -95,7 +103,7 @@ Return  the proper Storage Class
 {{- end -}}
 
 {{/*
-Pod annotations 
+Pod annotations
 */}}
 {{- define "common.classes.podAnnotations" -}}
   {{- if .Values.podAnnotations -}}

--- a/charts/flipt/templates/configmap.yaml
+++ b/charts/flipt/templates/configmap.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "flipt.fullname" . }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
   labels:
     {{- include "flipt.labels" . | nindent 4 }}
 data:

--- a/charts/flipt/templates/migration_job.yaml
+++ b/charts/flipt/templates/migration_job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.migration.enabled }}
+{{- if (.Values.migration).enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/flipt/templates/migration_job.yaml
+++ b/charts/flipt/templates/migration_job.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.migration.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "flipt.migration_name" . }}
+  labels:
+    {{- include "flipt.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  activeDeadlineSeconds: {{ .Values.migration.deadLine }}
+  backoffLimit: 0
+  template:
+    metadata:
+      annotations: {{- include "common.classes.podAnnotations" . | nindent 8 }}
+      labels:
+        {{- include "flipt.selectorLabels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "flipt.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+          - "./flipt"
+          - "migrate"
+          env:
+            - name: FLIPT_META_STATE_DIRECTORY
+              value: /home/flipt/.config/flipt
+            {{- if .Values.flipt.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.flipt.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - name: flipt-config
+              mountPath: /etc/flipt/config/default.yml
+              readOnly: true
+              subPath: default.yml
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: flipt-local-state
+          emptyDir: {}
+        - name: flipt-config
+          configMap:
+            name: {{ include "flipt.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{ end -}}

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -175,6 +175,14 @@ flipt:
         host: localhost
         port: 6831
 
+migration:
+  # If enabled will run the migration script over your db before rolling out
+  # a new deployment. This will run in a helm hook so will get cleaned up on
+  # success.
+  enabled: false
+  # How long to let the job run for kube will terminate it.
+  deadLine: 600 # sec
+
 metrics:
   serviceMonitor:
     # -- If enabled, ServiceMonitor resources for Prometheus Operator are created


### PR DESCRIPTION
This will run before an install or upgrade. It will block the deployment from going out if the migration fails. Helm will also clean up the job after it finishes running.

https://helm.sh/docs/topics/charts_hooks/#the-available-hooks

Fixes: https://github.com/flipt-io/helm-charts/issues/68. 

The request was for an init container but those will run any time a pod comes up, which could be fairly often if the HPA are flapping and has the potential to lock up the database if multiple migrations are run at the same time. Using a hook ensure that only 1 of these container will be running at any given time and only on initial deployment. 
