### PR TITLE
Allow tagging of the test container busybox

### DIFF
--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open source, self-hosted feature flag solution.
 type: application
-version: 0.36.0
+version: 0.36.1
 appVersion: v1.23.3
 maintainers:
   - name: Flipt

--- a/charts/flipt/templates/tests/test-connection.yaml
+++ b/charts/flipt/templates/tests/test-connection.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: busybox
+      image: busybox:{{ (.Values.test).tag | default "latest" }}
       command: ['wget']
       args: ['{{ include "flipt.fullname" . }}:{{ .Values.service.httpPort }}']
   restartPolicy: Never

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -19,6 +19,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+test:
+  # Can pin the version of busybox to a specific version
+  # tag: '1.36.1'
+
 podAnnotations: {}
 
 podSecurityContext:


### PR DESCRIPTION
I don't like relying on latest images since they can change under you unexpectedly. This give the option to pin to a version of busybox so each time you deploy you know which version you'll get