### PR TITLE
chore: try to better automate bump chart strategy

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install node
+        uses: actions/setup-node@v2.1.5
+        with:
+          node-version: "14"
+
       - name: Fetch Latest Flipt Release Tag
         id: fetch_tag
         env:
@@ -20,15 +25,15 @@ jobs:
         run: |
           tag=$(gh release view -R flipt-io/flipt --json tagName | jq -r .tagName)
           echo "tag=${tag}" >> $GITHUB_OUTPUT
-     
+
       - name: Update Chart Versions
         id: update_chart
         run: |
           tag="${{ steps.fetch_tag.outputs.tag }}"
-          # set current app version
-          yq e ".appVersion = \"${tag}\"" -i charts/flipt/Chart.yaml
-          # bump current chart MINOR version
-          yq e '.version' charts/flipt/Chart.yaml | awk -F. '{ print $1,$2+1,$3 }' OFS=. | xargs -I{} yq e '.version = "{}"' -i charts/flipt/Chart.yaml
+          pushd scripts/bumpVersion
+          npm install
+          npm run bump ../../charts/flipt/Chart.yaml "${tag}"
+          popd
 
       - name: Generate token
         id: generate_token
@@ -53,4 +58,3 @@ jobs:
           git push origin "update/${tag}"
           gh pr create --title "feat: update Flipt version to release ${tag}" \
             --body "Updating chart to Flipt release [${tag}](https://github.com/flipt-io/flipt/releases/tag/${tag})."
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ct_previous*
 .envrc
+node_modules

--- a/README.md
+++ b/README.md
@@ -9,6 +9,17 @@ These charts are still a work in progress.
 
 Please [create an issue](https://github.com/flipt-io/helm-charts/issues/new) or submit a pull request for any issues or missing features.
 
+## Versioning
+
+This project uses [Semantic Versioning](https://semver.org/).
+
+Our versioning strategy is based on the version of application that is packaged in the chart:
+
+- Each minor version bump of the application will also increase the minor version of the chart.
+- Each patch version bump of the application will also increase the patch version of the chart.
+
+**Note:** Some changes to the chart will not affect the application version. For example, if there is a bugfix or patch change to the chart that does not affect the application, the chart version will be incremented, but the application version will remain the same.
+
 ## Usage
 
 [Helm](https://helm.sh) must be installed to use the charts.

--- a/scripts/bumpVersion/main.js
+++ b/scripts/bumpVersion/main.js
@@ -1,0 +1,45 @@
+const fs = require("fs");
+const yaml = require("js-yaml");
+const semver = require("semver");
+
+// get path to YAML file from command line
+
+const filePath = process.argv[2];
+
+// get tag from command line
+const inputTag = process.argv[3];
+
+// Read YAML file
+const fileContents = fs.readFileSync(filePath, "utf8");
+const data = yaml.load(fileContents);
+
+// Get current appVersion
+const currentVersion = data.appVersion;
+
+// Compare versions
+if (semver.valid(inputTag) && semver.valid(currentVersion)) {
+  const diffType = semver.diff(currentVersion, inputTag);
+
+  // Determine if it's a minor or patch bump
+  if (diffType === "minor" || diffType === "patch") {
+    console.log(`The appVersion was bumped with a ${diffType} change.`);
+  } else {
+    console.error(
+      `The appVersion was bumped, but it's not a minor or patch change. It's a ${diffType} change.`
+    );
+  }
+
+  // Update appVersion
+  data.appVersion = inputTag;
+  // Update chart version using same strategy
+  version = data.version;
+  data.version = semver.inc(version, diffType);
+
+  // Write updated YAML back to file
+  const newYaml = yaml.dump(data);
+  fs.writeFileSync(filePath, newYaml, "utf8");
+
+  console.log("The appVersion and chart version were updated.");
+} else {
+  console.error("Invalid version(s).");
+}

--- a/scripts/bumpVersion/main.js
+++ b/scripts/bumpVersion/main.js
@@ -2,25 +2,26 @@ const fs = require("fs");
 const yaml = require("js-yaml");
 const semver = require("semver");
 
-// get path to YAML file from command line
+// Usage: node scripts/bumpVersion/main.js path/to/Chart.yaml $TAG
 
+// get path to YAML file from command line
 const filePath = process.argv[2];
 
 // get tag from command line
 const inputTag = process.argv[3];
 
-// Read YAML file
+// read YAML file
 const fileContents = fs.readFileSync(filePath, "utf8");
 const data = yaml.load(fileContents);
 
-// Get current appVersion
+// get current appVersion
 const currentVersion = data.appVersion;
 
-// Compare versions
+// compare versions
 if (semver.valid(inputTag) && semver.valid(currentVersion)) {
   const diffType = semver.diff(currentVersion, inputTag);
 
-  // Determine if it's a minor or patch bump
+  // determine if it's a minor or patch bump
   if (diffType === "minor" || diffType === "patch") {
     console.log(`The appVersion was bumped with a ${diffType} change.`);
   } else {
@@ -30,13 +31,13 @@ if (semver.valid(inputTag) && semver.valid(currentVersion)) {
     return 1;
   }
 
-  // Update appVersion
+  // update appVersion
   data.appVersion = inputTag;
-  // Update chart version using same strategy
+  // update chart version using same strategy
   version = data.version;
   data.version = semver.inc(version, diffType);
 
-  // Write updated YAML back to file
+  // write updated YAML back to file
   const newYaml = yaml.dump(data);
   fs.writeFileSync(filePath, newYaml, "utf8");
 

--- a/scripts/bumpVersion/main.js
+++ b/scripts/bumpVersion/main.js
@@ -27,6 +27,7 @@ if (semver.valid(inputTag) && semver.valid(currentVersion)) {
     console.error(
       `The appVersion was bumped, but it's not a minor or patch change. It's a ${diffType} change.`
     );
+    return 1;
   }
 
   // Update appVersion

--- a/scripts/bumpVersion/package-lock.json
+++ b/scripts/bumpVersion/package-lock.json
@@ -1,0 +1,99 @@
+{
+  "name": "bumpversion",
+  "version": "0.0.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bumpversion",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^4.1.0",
+        "semver": "^7.5.4"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    }
+  },
+  "dependencies": {
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    }
+  }
+}

--- a/scripts/bumpVersion/package.json
+++ b/scripts/bumpVersion/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "bumpversion",
+  "version": "0.0.1",
+  "description": "",
+  "main": "main.js",
+  "scripts": {
+    "bump": "node main.js"
+  },
+  "keywords": [],
+  "author": "Flipt Devs <dev@flipt.io>",
+  "license": "MIT",
+  "dependencies": {
+    "js-yaml": "^4.1.0",
+    "semver": "^7.5.4"
+  }
+}


### PR DESCRIPTION
Fixes: #85

Try to better automate keeping `verison` and `appVersion` in sync strategy wise.

This should:
- set `appVersion` to latest Flipt tag
- set `version` according to the semver change to `appVersion`:
  - if `minor` bump, bump `version` minor
  - if `patch` bump, bump `version` patch

This is inline with our versioning strategy #85 