### PR TITLE
chore: update Docker registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 ![Chart Version](https://img.shields.io/github/v/release/flipt-io/helm-charts?label=chart%20version)
 ![Flipt Version](https://img.shields.io/github/v/release/flipt-io/flipt?color=green&label=flipt%20version)
 
-These charts are still a work in progress.
-
 Please [create an issue](https://github.com/flipt-io/helm-charts/issues/new) or submit a pull request for any issues or missing features.
 
 ## Versioning

--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open-source, self-hosted feature flag solution.
 type: application
-version: 0.42.1
+version: 0.43.0
 appVersion: v1.29.1
 maintainers:
   - name: Flipt

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: flipt/flipt
+  repository: docker.flipt.io/flipt/flipt
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
@@ -40,7 +40,6 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 100
 
-
 ## Expose the flipt service to be accessed from outside the cluster (LoadBalancer service).
 ## or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it.
 ## ref: http://kubernetes.io/docs/user-guide/services/
@@ -57,7 +56,8 @@ service:
 ingress:
   enabled: false
   className: ""
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
@@ -70,7 +70,8 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: {}
+resources:
+  {}
   # limits:
   #   cpu: 100m
   #   memory: 128Mi


### PR DESCRIPTION
use our custom docker registry (proxy) so we can change from Docker Hub to ghcr.io if need be