### PR TITLE
feat: add support for extra volumes

### DIFF
--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open-source, self-hosted feature flag solution.
 type: application
-version: 0.44.1
+version: 0.44.2
 appVersion: v1.30.1
 maintainers:
   - name: Flipt

--- a/charts/flipt/templates/deployment.yaml
+++ b/charts/flipt/templates/deployment.yaml
@@ -55,6 +55,9 @@ spec:
             {{- if .Values.persistence.subPath }}
               subPath: {{ .Values.persistence.subPath }}
             {{- end }}
+            {{ if .Values.extraVolumeMounts }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /health
@@ -79,6 +82,9 @@ spec:
             claimName: {{ default (include "flipt.fullname" .) .Values.persistence.existingClaim }}
         {{- else }}
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -189,3 +189,15 @@ metrics:
     scheme: http
     # -- ServiceMonitor will use these tlsConfig settings to make the health check requests
     tlsConfig: null
+
+# extraVolumeMounts is a list of extra volumes to mount to the flipt container
+# - name: flipt-git-ssh-key
+#   mountPath: /etc/flipt/ssh.key
+#   subPath: ssh.key
+extraVolumeMounts: []
+
+# extraVolumes is a list of extra volumes to mount to the pod
+# - name: flipt-git-ssh-key
+#   secret:
+#     secretName: flit-git-ssh-key-secret
+extraVolumes: []


### PR DESCRIPTION
Add support for extra volumes. This can be useful for mounting files from k8s secrets and referencing them from the flipt config (e.g. Git SSH key files).