### PR TITLE
feat(ssh): add field for configuring ssh known hosts

### DIFF
--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open-source, self-hosted feature flag solution.
 type: application
-version: 0.44.2
+version: 0.45.0
 appVersion: v1.30.1
 maintainers:
   - name: Flipt

--- a/charts/flipt/templates/configmap_ssh.yaml
+++ b/charts/flipt/templates/configmap_ssh.yaml
@@ -1,0 +1,12 @@
+{{- if (.Values.ssh).knownHosts }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "flipt.fullname" . }}-ssh-known-hosts
+  labels:
+    {{- include "flipt.labels" . | nindent 4 }}
+data:
+  ssh_known_hosts: |
+    {{- .Values.ssh.knownHosts | nindent 4 }}
+{{- end }}

--- a/charts/flipt/templates/deployment.yaml
+++ b/charts/flipt/templates/deployment.yaml
@@ -43,6 +43,10 @@ spec:
             {{- if .Values.flipt.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.flipt.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+            {{- if (.Values.ssh).knownHosts }}
+            - name: SSH_KNOWN_HOSTS
+              value: /etc/flipt/known_hosts
+            {{- end }}
           volumeMounts:
             - name: flipt-local-state
               mountPath: /home/flipt/.config/flipt
@@ -57,6 +61,11 @@ spec:
             {{- end }}
             {{ if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+            {{- if (.Values.ssh).knownHosts }}
+            - name: flipt-ssh-known-hosts
+              mountPath: /etc/flipt/ssh_known_hosts
+              readOnly: true
             {{- end }}
           livenessProbe:
             httpGet:
@@ -85,6 +94,11 @@ spec:
         {{- end }}
         {{- if .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- end }}
+        {{- if (.Values.ssh).knownHosts }}
+        - name: flipt-ssh-known-hosts
+          configMap:
+            name: {{ include "flipt.fullname" . }}-ssh-known-hosts
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/flipt/templates/deployment.yaml
+++ b/charts/flipt/templates/deployment.yaml
@@ -66,6 +66,7 @@ spec:
             - name: flipt-ssh-known-hosts
               mountPath: /etc/flipt/ssh_known_hosts
               readOnly: true
+              subPath: ssh_known_hosts
             {{- end }}
           livenessProbe:
             httpGet:

--- a/charts/flipt/templates/deployment.yaml
+++ b/charts/flipt/templates/deployment.yaml
@@ -59,14 +59,14 @@ spec:
             {{- if .Values.persistence.subPath }}
               subPath: {{ .Values.persistence.subPath }}
             {{- end }}
-            {{ if .Values.extraVolumeMounts }}
-            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
-            {{- end }}
             {{- if (.Values.ssh).knownHosts }}
             - name: flipt-ssh-known-hosts
               mountPath: /etc/flipt/ssh_known_hosts
               readOnly: true
               subPath: ssh_known_hosts
+            {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
           livenessProbe:
             httpGet:
@@ -93,13 +93,13 @@ spec:
         {{- else }}
           emptyDir: {}
         {{- end }}
-        {{- if .Values.extraVolumes }}
-        {{- toYaml .Values.extraVolumes | nindent 8 }}
-        {{- end }}
         {{- if (.Values.ssh).knownHosts }}
         - name: flipt-ssh-known-hosts
           configMap:
             name: {{ include "flipt.fullname" . }}-ssh-known-hosts
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -201,3 +201,9 @@ extraVolumeMounts: []
 #   secret:
 #     secretName: flit-git-ssh-key-secret
 extraVolumes: []
+
+# ssh contains some SSH specific configuration parameters
+ssh:
+  # knownHosts is the contents of a custom known hosts file
+  # for use with SSH authentication and the Git backend for Flipt
+  knownHosts: ""


### PR DESCRIPTION
Supports https://github.com/flipt-io/flipt/issues/2386

This adds a new configuration `ssh.knownHosts` which allows the user to override the known hosts configuration for Flipt. The user should put the entire contents of the known hosts file they want in this field.

Configuring a non-empty string for known hosts creates:
- configmap
- volume
- volumeMount
- env var entry

cc @jalaziz 