### PR TITLE
fix(chart): Fix SSH_KNOWN_HOSTS env var file path

### DIFF
--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open-source, self-hosted feature flag solution.
 type: application
-version: 0.46.0
+version: 0.46.1
 appVersion: v1.31.0
 maintainers:
   - name: Flipt

--- a/charts/flipt/templates/deployment.yaml
+++ b/charts/flipt/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
             {{- end }}
             {{- if (.Values.ssh).knownHosts }}
             - name: SSH_KNOWN_HOSTS
-              value: /etc/flipt/known_hosts
+              value: /etc/flipt/ssh_known_hosts
             {{- end }}
           volumeMounts:
             - name: flipt-local-state


### PR DESCRIPTION
When `ssh.knownHosts` is provided, the path set in the `SSH_KNOWN_HOSTS` environment variable did not match the file mounted from the config map.