### PR TITLE
feat(charts/flipt): add support for envFrom

### DIFF
--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open-source, self-hosted feature flag solution.
 type: application
-version: 0.55.2
+version: 0.56.0
 appVersion: v1.39.2
 maintainers:
   - name: Flipt

--- a/charts/flipt/templates/deployment.yaml
+++ b/charts/flipt/templates/deployment.yaml
@@ -49,6 +49,10 @@ spec:
             - name: SSH_KNOWN_HOSTS
               value: /etc/flipt/ssh_known_hosts
             {{- end }}
+          {{- if .Values.flipt.envFrom }}
+          envFrom:
+            {{- toYaml .Values.flipt.envFrom | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: flipt-local-state
               mountPath: /home/flipt/.config/flipt

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -138,6 +138,7 @@ flipt:
   # - name: FLIPT_LOG_LEVEL
   #   value: debug
   extraEnvVars: []
+  envFrom: []
   config:
     log:
       level: INFO


### PR DESCRIPTION
Fixes #134 

Adds support for `envFrom` to `flipt` configuration section in Values.yml

cc @nopasutsamp