### PR TITLE
feat: Include the seccompProfile in default securityContext

### DIFF
--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open-source, self-hosted feature flag solution.
 type: application
-version: 0.57.0
+version: 0.58.0
 appVersion: v1.40.0
 maintainers:
   - name: Flipt

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -40,6 +40,8 @@ securityContext:
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 100
+  seccompProfile:
+    type: "RuntimeDefault"
 
 ## Expose the flipt service to be accessed from outside the cluster (LoadBalancer service).
 ## or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it.


### PR DESCRIPTION
This change enabled deploying this helm chart, out-of-the-box, into a namespace
that has restricted PSS (pod security standards -- the replacement to PSP) enforcement enabled.

Read more about PSS here: https://kubernetes.io/docs/concepts/security/pod-security-standards/