### PR TITLE
fix(charts/flipt): add envFrom to migration job

### DIFF
--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open-source, self-hosted feature flag solution.
 type: application
-version: 0.58.1
+version: 0.58.2
 appVersion: v1.40.1
 maintainers:
   - name: Flipt

--- a/charts/flipt/templates/migration_job.yaml
+++ b/charts/flipt/templates/migration_job.yaml
@@ -41,6 +41,10 @@ spec:
             {{- if .Values.flipt.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.flipt.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+          {{- if .Values.flipt.envFrom }}
+          envFrom:
+            {{- toYaml .Values.flipt.envFrom | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: flipt-config
               mountPath: /etc/flipt/config/default.yml


### PR DESCRIPTION
Adds `envFrom` to the migration job spec.
