### PR TITLE
feat: allow specifying additional pod labels

### DIFF
--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open-source, self-hosted feature flag solution.
 type: application
-version: 0.61.0
+version: 0.62.0
 appVersion: v1.43.0
 maintainers:
   - name: Flipt

--- a/charts/flipt/templates/deployment.yaml
+++ b/charts/flipt/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
       annotations: {{- include "common.classes.podAnnotations" . | nindent 8 }}
       labels:
         {{- include "flipt.selectorLabels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -25,6 +25,7 @@ test:
   # tag: '1.36.1'
 
 podAnnotations: {}
+podLabels: {}
 
 podSecurityContext:
   runAsUser: 100


### PR DESCRIPTION
Additional pod labels are often needed, for instance, when configuring Istio injection.