### PR TITLE
feat: include servicemonitor additional labels to template

### DIFF
--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open-source, self-hosted feature flag solution.
 type: application
-version: 0.64.0
+version: 0.65.0
 appVersion: v1.45.0
 maintainers:
   - name: Flipt

--- a/charts/flipt/templates/servicemonitor.yaml
+++ b/charts/flipt/templates/servicemonitor.yaml
@@ -8,6 +8,9 @@ metadata:
   {{- end }}
   labels:
     {{- include "flipt.labels" . | nindent 4 }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
     - port: {{ .Values.metrics.serviceMonitor.port | quote }}


### PR DESCRIPTION
Additional labels that can be used so ServiceMonitor resource can be discovered by Prometheus

`.Values.metrics.serviceMonitor.labels` is already defined in `values.yaml` but was not used