### PR TITLE
feat(charts/flipt): add support for custom args

### DIFF
--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open-source, self-hosted feature flag solution.
 type: application
-version: 0.70.0
+version: 0.70.1
 appVersion: v1.50.0
 maintainers:
   - name: Flipt

--- a/charts/flipt/templates/deployment.yaml
+++ b/charts/flipt/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: "/flipt"
+          command: ["/flipt"]
           {{- if .Values.flipt.args }}
           args:
           {{- toYaml .Values.flipt.args | nindent 12 }}

--- a/charts/flipt/templates/deployment.yaml
+++ b/charts/flipt/templates/deployment.yaml
@@ -35,6 +35,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: "/flipt"
+          {{- if .Values.flipt.args }}
+          args:
+          {{- toYaml .Values.flipt.args | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ coalesce ((.Values.flipt.config).server).http_port .Values.flipt.httpPort .Values.containerPorts.http }}

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -137,6 +137,7 @@ flipt:
   # grpcPort is the Flipt GRPC container port
   # @deprecated use containerPorts.grpc instead
   grpcPort: 9000
+  args: []
   # extraEnvVars is a list of extra environment variables to set e.g.
   # - name: FLIPT_LOG_LEVEL
   #   value: debug


### PR DESCRIPTION
This allows the configurer to provide other arguments to the `flipt` command (e.g. `--force-migrate`).