### PR TITLE
fix: use selectorLabels in pdb

### DIFF
--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open-source, self-hosted feature flag solution.
 type: application
-version: 0.72.1
+version: 0.72.2
 appVersion: v1.51.1
 maintainers:
   - name: Flipt

--- a/charts/flipt/templates/pdb.yaml
+++ b/charts/flipt/templates/pdb.yaml
@@ -10,5 +10,5 @@ spec:
   maxUnavailable: {{ default "25%" .Values.pdb.maxUnavailable }} 
   selector:
     matchLabels:
-      {{- include "flipt.labels" . | nindent 6 }}
+      {{- include "flipt.selectorLabels" . | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
Switch to `flipt.selectorLabels` in the pdb as all requirements from `matchLabels` are ANDed together ([docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements)). If `flipt.labels` has other labels configured, the pdb will never match.

https://github.com/flipt-io/helm-charts/blob/0ac3dd2cb637e80d213eab7b126bc24ff2feb908/charts/flipt/templates/deployment.yaml#L21-L25
