### PR TITLE
fix: mount persistence PVC into migration

### DIFF
--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open-source, self-hosted feature flag solution.
 type: application
-version: 0.72.2
+version: 0.72.3
 appVersion: v1.51.1
 maintainers:
   - name: Flipt

--- a/charts/flipt/templates/migration_job.yaml
+++ b/charts/flipt/templates/migration_job.yaml
@@ -51,6 +51,8 @@ spec:
               mountPath: /etc/flipt/config/default.yml
               readOnly: true
               subPath: default.yml
+            - name: flipt-data
+              mountPath: /var/opt/flipt
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -59,6 +61,13 @@ spec:
         - name: flipt-config
           configMap:
             name: {{ include "flipt.fullname" . }}
+        - name: flipt-data
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ default (include "flipt.fullname" .) .Values.persistence.existingClaim }}
+        {{- else }}
+          emptyDir: { }
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
fixes: https://github.com/flipt-io/flipt/issues/3616

Hey, when using --set migrations.enabled=true, and using --set persistence.enabled=true with SQLite, migrations fail because the persistent volume is not mounted into the pod of the migration job.
For testing and eval systems, using the SQLite is good enough and so it would be good to also be able to run the migrations automatically on them.
I created a copy of the migration job pod with the PVC mounted and it worked well!

