### PR TITLE
Expose liveness and readiness probe configuration in values settings

### DIFF
--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open-source, self-hosted feature flag solution.
 type: application
-version: 0.72.2
+version: 0.73.0
 appVersion: v1.51.1
 maintainers:
   - name: Flipt

--- a/charts/flipt/templates/deployment.yaml
+++ b/charts/flipt/templates/deployment.yaml
@@ -88,15 +88,9 @@ spec:
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
           livenessProbe:
-            httpGet:
-              path: /health
-              port: http
-            initialDelaySeconds: 3
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: http
-            initialDelaySeconds: 3
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -44,6 +44,18 @@ securityContext:
   seccompProfile:
     type: "RuntimeDefault"
 
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 3
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 3
+
 ## Expose the flipt service to be accessed from outside the cluster (LoadBalancer service).
 ## or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it.
 ## ref: http://kubernetes.io/docs/user-guide/services/


### PR DESCRIPTION
Different environments and different configuration may have different expectations for liveness and readiness.

We have experienced that the initial startup using declarative 'git' backend can take 30s or more on some occasions, which means that the default liveness probe would kill the container before it could complete.

By exposing these for users to override and configure, alternative initialDelay, periodSeconds, and thresholds are able to be tweaked and refined to support the user's specific expectations.

By default, the same probes that were previously hardcoded are configured in the defaulti values.yaml.