### PR TITLE
feat: allow configuring https ports

### DIFF
--- a/charts/flipt/templates/deployment.yaml
+++ b/charts/flipt/templates/deployment.yaml
@@ -49,6 +49,9 @@ spec:
             - name: http
               containerPort: {{ coalesce ((.Values.flipt.config).server).http_port .Values.flipt.httpPort .Values.containerPorts.http }}
               protocol: TCP
+            - name: https
+              containerPort: {{ coalesce ((.Values.flipt.config).server).https_port .Values.containerPorts.https }}
+              protocol: TCP
             - name: grpc
               containerPort: {{ coalesce ((.Values.flipt.config).server).grpc_port .Values.flipt.grpcPort .Values.containerPorts.grpc }}
               protocol: TCP

--- a/charts/flipt/templates/service.yaml
+++ b/charts/flipt/templates/service.yaml
@@ -41,6 +41,10 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: {{ .Values.service.httpsPort }}
+      targetPort: https
+      protocol: TCP
+      name: https
     - port: {{ .Values.service.grpcPort }}
       targetPort: grpc
       protocol: TCP

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -64,6 +64,7 @@ service:
   enabled: true
   type: ClusterIP
   httpPort: 8080
+  httpsPort: 443
   grpcPort: 9000
   ## Service annotations. Can be templated.
   annotations: {}
@@ -116,6 +117,8 @@ strategy: {}
 containerPorts:
   ## http is the Flipt HTTP container port
   http: 8080
+  ## https is the Flipt HTTPS container port
+  https: 443
   ## grpc Flipt GRPC container port
   grpc: 9000
 


### PR DESCRIPTION
request from Discord to be able to specify httpsPorts in helm chart

Note: I'm not sure if this is all that's needed to support e2e TLS or if there is more we need to add to the chart