### PR TITLE
fix: use the latest version of Flipt

### DIFF
--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,8 +3,8 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open-source, self-hosted feature flag solution.
 type: application
-version: 0.76.0
-appVersion: v1.53.0
+version: 0.76.1
+appVersion: v1.53.1
 maintainers:
   - name: Flipt
     url: https://github.com/flipt-io/helm-charts


### PR DESCRIPTION
In #193 the latest app version was changed to previous one. 