### PR TITLE
feat: expose honorLabels key in ServiceMonitor

### DIFF
--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open-source, self-hosted feature flag solution.
 type: application
-version: 0.76.1
+version: 0.77.0
 appVersion: v1.53.1
 maintainers:
   - name: Flipt

--- a/charts/flipt/templates/servicemonitor.yaml
+++ b/charts/flipt/templates/servicemonitor.yaml
@@ -18,6 +18,7 @@ spec:
       interval: {{ . }}
       {{- end }}
       path: /metrics
+      honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
       {{- with .Values.metrics.serviceMonitor.relabelings }}
       relabelings:
         {{- toYaml . | nindent 8 }}

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -207,6 +207,9 @@ metrics:
     # -- ServiceMonitor relabel configs to apply to samples before scraping
     # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
     relabelings: []
+    # -- What to do when flipt metrics labels are conflicting with Prometheus server-side labels.
+    # true means keep label values from flipt.
+    honorLabels: false
     # -- ServiceMonitor will use http by default, but you can pick https as well
     scheme: http
     # -- ServiceMonitor will use these tlsConfig settings to make the health check requests


### PR DESCRIPTION
Discussion: https://community.flipt.io/t/prometheus-as-source-for-analytics/58/11

Prometheus config defaults to `false`, so this PR would not change any behaviour.