### PR TITLE
fix: add extraVolumes and extraVolumeMounts to migration job

### DIFF
--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open-source, self-hosted feature flag solution.
 type: application
-version: 0.87.0
+version: 0.87.1
 appVersion: v1.61.0
 maintainers:
   - name: Flipt

--- a/charts/flipt/templates/migration_job.yaml
+++ b/charts/flipt/templates/migration_job.yaml
@@ -53,6 +53,9 @@ spec:
               subPath: default.yml
             - name: flipt-data
               mountPath: /var/opt/flipt
+            {{- if .Values.extraVolumeMounts }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -67,6 +70,9 @@ spec:
             claimName: {{ default (include "flipt.fullname" .) .Values.persistence.existingClaim }}
         {{- else }}
           emptyDir: { }
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
Migration job fails with `Error: loading configuration: field "public_key_file": stat /etc/flipt/jwt/public_key.pem: no such file or directory` when config contains `authentication:methods:jwt:public_key_file` configured as ConfigMap mount via extraVolumes, extraVolumeMounts and extraDeploy.