### PR TITLE
feat(flipt-v2): add option to set additional labels on PVC

### DIFF
--- a/charts/flipt-v2/Chart.yaml
+++ b/charts/flipt-v2/Chart.yaml
@@ -5,7 +5,7 @@ description: >-
   Flipt v2 is a Git-native, open-source feature flag solution with enhanced
   authentication and multi-environment support.
 type: application
-version: 2.6.0
+version: 2.6.1
 appVersion: v2.6.0
 maintainers:
   - name: Flipt

--- a/charts/flipt-v2/templates/pvc.yaml
+++ b/charts/flipt-v2/templates/pvc.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "flipt-v2.labels" . | nindent 4 }}
+    {{- with .Values.persistence.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- if or .Values.persistence.annotations .Values.commonAnnotations }}
   annotations:
     {{- if .Values.persistence.annotations }}

--- a/charts/flipt-v2/values.yaml
+++ b/charts/flipt-v2/values.yaml
@@ -144,6 +144,8 @@ containerPorts:
 persistence:
   ## enabled enables persistence using Persistent Volume Claims
   enabled: false
+  ## labels are additional custom labels for the PVC                                                       │
+  labels: {}
   ## annotations are additional custom annotations for the PVC
   annotations: {}
   ## existingClaim sets the name of an existing PVC to use for persistence


### PR DESCRIPTION
Enhances the configuration of persistent volume claims (PVCs) in the `flipt-v2` Helm chart by introducing support for custom labels. These changes improve flexibility for users who want to add custom metadata to their PVCs.