### PR TITLE
fix: add Gateway API support

### DIFF
--- a/charts/flipt-v2/Chart.yaml
+++ b/charts/flipt-v2/Chart.yaml
@@ -5,7 +5,7 @@ description: >-
   Flipt v2 is a Git-native, open-source feature flag solution with enhanced
   authentication and multi-environment support.
 type: application
-version: 2.8.0
+version: 2.8.1
 appVersion: v2.8.0
 maintainers:
   - name: Flipt
@@ -19,3 +19,4 @@ keywords:
 sources:
   - https://github.com/flipt-io/flipt
   - https://github.com/flipt-io/helm-charts
+icon: https://flipt.io/favicon.png

--- a/charts/flipt-v2/templates/gateway.yaml
+++ b/charts/flipt-v2/templates/gateway.yaml
@@ -1,0 +1,67 @@
+{{- if and .Values.gateway.enabled (not .Values.ingress.enabled) -}}
+{{- $fullName := include "flipt-v2.fullname" . -}}
+{{- $httpHosts := .Values.gateway.http.hosts | default (list) -}}
+{{- $tlsHosts := list -}}
+{{- if and .Values.gateway.tls (gt (len .Values.gateway.tls) 0) -}}
+{{- $tlsHosts = (index .Values.gateway.tls 0).hosts | default (list) -}}
+{{- end -}}
+{{- $allHosts := concat $httpHosts $tlsHosts | uniq -}}
+{{- if .Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1" -}}
+# Gateway
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ $fullName }}-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flipt-v2.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ .Values.gateway.className }}
+  listeners:
+  {{- range $httpHosts }}
+  - name: http-{{ . | trunc 63 | trimSuffix "-" }}
+    protocol: HTTP
+    port: 80
+    hostname: {{ . | quote }}
+  {{- end }}
+  {{- range .Values.gateway.tls }}
+  {{- $current := . -}}
+  {{- range $current.hosts }}
+  - name: https-{{ . | trunc 63 | trimSuffix "-" }}
+    protocol: HTTPS
+    port: 443
+    hostname: {{ . | quote }}
+    tls:
+      mode: {{ $current.mode | default "Terminate" }}
+      certificateRefs:
+        - name: {{ $current.secretName }}
+  {{- end }}
+  {{- end }}
+---
+# HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}-http
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flipt-v2.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ $fullName }}-gateway
+      namespace: {{ .Release.Namespace }}
+  hostnames:
+  {{- range $allHosts }}
+    - {{ . | quote }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $.Values.service.httpPort }}
+
+{{- end }}
+{{- end }}

--- a/charts/flipt-v2/values.schema.json
+++ b/charts/flipt-v2/values.schema.json
@@ -191,6 +191,67 @@
       "type": "array",
       "default": []
     },
+    "gateway": {
+      "additionalProperties": true,
+      "properties": {
+        "annotations": {
+          "additionalProperties": true,
+          "title": "annotations",
+          "type": "object",
+          "default": {}
+        },
+        "className": {
+          "default": "",
+          "title": "className",
+          "type": "string"
+        },
+        "enabled": {
+          "default": false,
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "http": {
+          "properties": {
+            "hosts": {
+              "items": {
+                "type": "string"
+              },
+              "title": "hosts",
+              "type": "array",
+              "default": []
+            }
+          },
+          "type": "object"
+        },
+        "tls": {
+          "items": {
+            "properties": {
+              "secretName": {
+                "type": "string"
+              },
+              "mode": {
+                "default": "Terminate",
+                "title": "mode",
+                "type": "string"
+              },
+              "hosts": {
+                "items": {
+                  "type": "string"
+                },
+                "title": "hosts",
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "title": "tls",
+          "type": "array",
+          "default": []
+        }
+      },
+      "title": "gateway",
+      "type": "object"
+    },
     "ingress": {
       "additionalProperties": true,
       "properties": {

--- a/charts/flipt-v2/values.yaml
+++ b/charts/flipt-v2/values.yaml
@@ -80,8 +80,7 @@ service:
 ingress:
   enabled: false
   className: ""
-  annotations:
-    {}
+  annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
@@ -102,8 +101,19 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources:
-  {}
+gateway:
+  enabled: false
+  className: ""
+  annotations: {}
+  http:
+    hosts: [flipt.local]
+  tls: []
+  #  - secretName: chart-example-tls
+  #    mode: Terminate
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -256,7 +266,6 @@ flipt:
   #     gpg:
   #       private_key_path: ""
   #       password: ""
-
 
 metrics:
   serviceMonitor:

--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,8 +3,9 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open-source, self-hosted feature flag solution.
 type: application
-version: 0.87.6
+version: 0.87.7
 appVersion: v1.61.1
 maintainers:
   - name: Flipt
     url: https://github.com/flipt-io/helm-charts
+icon: https://flipt.io/favicon.png

--- a/charts/flipt/templates/gateway.yaml
+++ b/charts/flipt/templates/gateway.yaml
@@ -1,0 +1,67 @@
+{{- if and .Values.gateway.enabled (not .Values.ingress.enabled) -}}
+{{- $fullName := include "flipt.fullname" . -}}
+{{- $httpHosts := .Values.gateway.http.hosts | default (list) -}}
+{{- $tlsHosts := list -}}
+{{- if and .Values.gateway.tls (gt (len .Values.gateway.tls) 0) -}}
+{{- $tlsHosts = (index .Values.gateway.tls 0).hosts | default (list) -}}
+{{- end -}}
+{{- $allHosts := concat $httpHosts $tlsHosts | uniq -}}
+{{- if .Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1" -}}
+# Gateway
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ $fullName }}-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flipt.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ .Values.gateway.className }}
+  listeners:
+  {{- range $httpHosts }}
+  - name: http-{{ . | trunc 63 | trimSuffix "-" }}
+    protocol: HTTP
+    port: 80
+    hostname: {{ . | quote }}
+  {{- end }}
+  {{- range .Values.gateway.tls }}
+  {{- $current := . -}}
+  {{- range $current.hosts }}
+  - name: https-{{ . | trunc 63 | trimSuffix "-" }}
+    protocol: HTTPS
+    port: 443
+    hostname: {{ . | quote }}
+    tls:
+      mode: {{ $current.mode | default "Terminate" }}
+      certificateRefs:
+        - name: {{ $current.secretName }}
+  {{- end }}
+  {{- end }}
+---
+# HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}-http
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flipt.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ $fullName }}-gateway
+      namespace: {{ .Release.Namespace }}
+  hostnames:
+  {{- range $allHosts }}
+    - {{ . | quote }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $.Values.service.httpPort }}
+
+{{- end }}
+{{- end }}

--- a/charts/flipt/values.schema.json
+++ b/charts/flipt/values.schema.json
@@ -280,6 +280,70 @@
       "title": "ingress",
       "type": "object"
     },
+    "gateway": {
+      "additionalProperties": true,
+      "properties": {
+        "annotations": {
+          "additionalProperties": true,
+          "title": "annotations",
+          "type": "object",
+          "default": {}
+        },
+        "className": {
+          "default": "",
+          "title": "className",
+          "type": "string"
+        },
+        "enabled": {
+          "default": false,
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "http": {
+          "properties": {
+            "hosts": {
+              "items": {
+                "type": "string"
+              },
+              "title": "hosts",
+              "type": "array",
+              "default": ["flipt.local"]
+            }
+          },
+          "title": "http",
+          "type": "object"
+        },
+        "tls": {
+          "items": {
+            "properties": {
+              "hosts": {
+                "items": {
+                  "type": "string"
+                },
+                "title": "hosts",
+                "type": "array"
+              },
+              "mode": {
+                "default": "Terminate",
+                "title": "mode",
+                "type": "string"
+              },
+              "secretName": {
+                "title": "secretName",
+                "type": "string"
+              }
+            },
+            "required": ["secretName", "hosts"],
+            "type": "object"
+          },
+          "title": "tls",
+          "type": "array",
+          "default": []
+        }
+      },
+      "title": "gateway",
+      "type": "object"
+    },
     "kubeVersionOverride": {
       "title": "kubeVersionOverride",
       "type": "string"

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -102,6 +102,18 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+gateway:
+  enabled: false
+  className: ""
+  annotations: {}
+  http:
+    hosts: [flipt.local]
+  tls: []
+  #  - secretName: chart-example-tls
+  #    mode: Terminate
+  #    hosts:
+  #      - chart-example.local
+
 resources:
   {}
   # limits:


### PR DESCRIPTION
Add Gateway API and HTTPRoute resources to v1 and v2 charts. Includes gateway configuration in values.yaml and corresponding schema validation.

closes #277 