### PR TITLE
feat(flipt-v2): add possibility to deploy as StatefulSet

### DIFF
--- a/charts/flipt-v2/Chart.yaml
+++ b/charts/flipt-v2/Chart.yaml
@@ -5,8 +5,8 @@ description: >-
   Flipt v2 is a Git-native, open-source feature flag solution with enhanced
   authentication and multi-environment support.
 type: application
-version: 2.10.0
-appVersion: v2.10.0
+version: 2.9.1
+appVersion: v2.9.0
 maintainers:
   - name: Flipt
     url: https://github.com/flipt-io/helm-charts

--- a/charts/flipt-v2/Chart.yaml
+++ b/charts/flipt-v2/Chart.yaml
@@ -5,8 +5,8 @@ description: >-
   Flipt v2 is a Git-native, open-source feature flag solution with enhanced
   authentication and multi-environment support.
 type: application
-version: 2.9.0
-appVersion: v2.9.0
+version: 2.10.0
+appVersion: v2.10.0
 maintainers:
   - name: Flipt
     url: https://github.com/flipt-io/helm-charts

--- a/charts/flipt-v2/templates/_helpers.tpl
+++ b/charts/flipt-v2/templates/_helpers.tpl
@@ -122,6 +122,14 @@ Deployment annotations
   {{- printf "checksum/config: %v" (join "," .Values.flipt | sha256sum) | nindent 0 -}}
 {{- end -}}
 
+{{/*
+Create the name for the headless service used by StatefulSet.
+Truncated to 63 chars to account for the appended "-headless" suffix.
+*/}}
+{{- define "flipt-v2.headlessName" -}}
+{{- printf "%s-headless" (include "flipt-v2.fullname" . | trunc 54 | trimSuffix "-") }}
+{{- end }}
+
 {{/* Return the target Kubernetes version */}}
 {{- define "flipt-v2.tools.kubeVersion" -}}
 {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride }}

--- a/charts/flipt-v2/templates/deployment.yaml
+++ b/charts/flipt-v2/templates/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ ternary "Deployment" "StatefulSet" (eq (lower .Values.kind) "deployment") }}
 metadata:
   name: {{ include "flipt-v2.fullname" . }}
   namespace: {{ .Release.Namespace }}
@@ -14,9 +14,17 @@ spec:
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   minReadySeconds: {{ .Values.minReadySeconds }}
+  {{- if eq (lower .Values.kind) "statefulset" }}
+  serviceName: {{ include "flipt-v2.headlessName" . }}
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
+  {{- end }}
   {{- with .Values.strategy }}
-  strategy:
-    {{- toYaml . | nindent 8 }}
+  {{ ternary "strategy" "updateStrategy" (eq (lower $.Values.kind) "deployment") }}:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if and (eq (lower .Values.kind) "statefulset") .Values.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml .Values.persistentVolumeClaimRetentionPolicy | nindent 4 }}
   {{- end }}
 
   selector:
@@ -112,12 +120,14 @@ spec:
         - name: flipt-config
           configMap:
             name: {{ include "flipt-v2.fullname" . }}
+        {{- if not (and (eq (lower .Values.kind) "statefulset") .Values.persistence.enabled (not .Values.persistence.existingClaim)) }}
         - name: flipt-data
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ default (include "flipt-v2.fullname" .) .Values.persistence.existingClaim }}
         {{- else }}
           emptyDir: {}
+        {{- end }}
         {{- end }}
         {{- if (.Values.ssh).knownHosts }}
         - name: flipt-ssh-known-hosts
@@ -143,3 +153,25 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  {{- if and (eq (lower .Values.kind) "statefulset") .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: flipt-data
+        {{- with .Values.persistence.labels }}
+        labels:
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.persistence.annotations }}
+        annotations:
+          {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
+        {{- end }}
+      spec:
+        accessModes:
+        {{- range .Values.persistence.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size | quote }}
+        {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 8 }}
+  {{- end }}

--- a/charts/flipt-v2/templates/hpa.yaml
+++ b/charts/flipt-v2/templates/hpa.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: {{ ternary "Deployment" "StatefulSet" (eq (lower .Values.kind) "deployment") }}
     name: {{ include "flipt-v2.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}

--- a/charts/flipt-v2/templates/pvc.yaml
+++ b/charts/flipt-v2/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq (lower .Values.kind) "deployment") -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/flipt-v2/templates/service-headless.yaml
+++ b/charts/flipt-v2/templates/service-headless.yaml
@@ -1,0 +1,27 @@
+{{- if eq (lower .Values.kind) "statefulset" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "flipt-v2.headlessName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flipt-v2.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: {{ .Values.service.httpPort }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.service.httpsPort }}
+      targetPort: https
+      protocol: TCP
+      name: https
+    - port: {{ .Values.service.grpcPort }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector:
+    {{- include "flipt-v2.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/flipt-v2/values.schema.json
+++ b/charts/flipt-v2/values.schema.json
@@ -809,6 +809,40 @@
       "items": {},
       "title": "topologySpreadConstraints",
       "type": "array"
+    },
+    "kind": {
+      "default": "Deployment",
+      "description": "Controls whether Flipt is deployed as a Deployment or StatefulSet.",
+      "enum": ["Deployment", "StatefulSet"],
+      "title": "kind",
+      "type": "string"
+    },
+    "podManagementPolicy": {
+      "default": "Parallel",
+      "description": "Pod management policy for StatefulSet. Only used when kind is StatefulSet.",
+      "enum": ["OrderedReady", "Parallel"],
+      "title": "podManagementPolicy",
+      "type": "string"
+    },
+    "persistentVolumeClaimRetentionPolicy": {
+      "additionalProperties": false,
+      "description": "Controls PVC lifecycle on StatefulSet deletion or scale-down. Only used when kind=StatefulSet.",
+      "title": "persistentVolumeClaimRetentionPolicy",
+      "type": "object",
+      "properties": {
+        "whenDeleted": {
+          "description": "What happens to PVCs when the StatefulSet is deleted.",
+          "enum": ["Retain", "Delete"],
+          "title": "whenDeleted",
+          "type": "string"
+        },
+        "whenScaled": {
+          "description": "What happens to PVCs when the StatefulSet is scaled down.",
+          "enum": ["Retain", "Delete"],
+          "title": "whenScaled",
+          "type": "string"
+        }
+      }
     }
   },
   "type": "object"

--- a/charts/flipt-v2/values.yaml
+++ b/charts/flipt-v2/values.yaml
@@ -1,6 +1,15 @@
 replicaCount: 1
 minReadySeconds: 0
 
+# kind controls whether Flipt is deployed as a Deployment or StatefulSet.
+# Use StatefulSet when stable network identities or volumeClaimTemplates are needed.
+# Allowed values: Deployment, StatefulSet
+kind: Deployment
+
+# podManagementPolicy is only used when kind is StatefulSet.
+# Allowed values: OrderedReady, Parallel
+podManagementPolicy: Parallel
+
 image:
   repository: docker.flipt.io/flipt/flipt
   pullPolicy: IfNotPresent
@@ -117,6 +126,9 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+  # Note: HPA works with StatefulSet but scale-down does NOT delete PVCs created by
+  # volumeClaimTemplates. Set persistentVolumeClaimRetentionPolicy.whenScaled=Delete
+  # to avoid orphaned PVCs accumulating over time.
 
 pdb:
   enabled: false
@@ -125,8 +137,22 @@ pdb:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+# strategy configures the rollout strategy.
+# For Deployments this maps to spec.strategy; for StatefulSets to spec.updateStrategy.
 strategy: {}
 topologySpreadConstraints: []
+
+# persistentVolumeClaimRetentionPolicy controls what happens to PVCs created by
+# volumeClaimTemplates when the StatefulSet is deleted or scaled down.
+# Only used when kind=StatefulSet.
+# whenDeleted: Retain|Delete — what to do with PVCs when the StatefulSet is deleted
+# whenScaled:  Retain|Delete — what to do with PVCs when the StatefulSet is scaled down
+# Note: if you enable HPA with kind=StatefulSet and leave whenScaled=Retain,
+#       orphaned PVCs will accumulate on scale-down.
+persistentVolumeClaimRetentionPolicy: {}
+# persistentVolumeClaimRetentionPolicy:
+#   whenDeleted: Retain
+#   whenScaled: Delete
 
 ## Container ports
 ##


### PR DESCRIPTION
## Summary

Adding a possibility to choose between `StatefulSet` and `Deployment` options for `flipt-v2`.

## Motivation

The current chart provisions a standalone `PersistentVolumeClaim` bound to a `Deployment`. This approach has some limitations:

- With `ReadWriteOnce` (default, e.g. AWS EBS), only one pod can mount the PVC at a time, forcing a single replica with no autoscaling and downtime on every pod replacement.
 - With `ReadWriteMany`, multiple pods can share the PVC, but this risks write contention and requires storage infrastructure that supports RWX - might not be available with the default StorageClass.

`StatefulSet` with `volumeClaimTemplates` gives each replica its own volume, enabling multiple replicas, rolling updates without downtime, and HPA.

## Backwards compatibility

`kind` defaults to `Deployment`; existing charts should remain unaffected.