### PR TITLE
fix(schema): relax schema for livenessProbe to allow additional properties

### DIFF
--- a/charts/flipt-v2/Chart.yaml
+++ b/charts/flipt-v2/Chart.yaml
@@ -5,7 +5,7 @@ description: >-
   Flipt v2 is a Git-native, open-source feature flag solution with enhanced
   authentication and multi-environment support.
 type: application
-version: 2.9.1
+version: 2.9.2
 appVersion: v2.9.0
 maintainers:
   - name: Flipt

--- a/charts/flipt-v2/values.schema.json
+++ b/charts/flipt-v2/values.schema.json
@@ -248,7 +248,7 @@
       "type": "object"
     },
     "livenessProbe": {
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "httpGet": {
           "additionalProperties": true,


### PR DESCRIPTION
https://github.com/flipt-io/helm-charts/pull/268/changes relaxed the schema for readinessProbe, but missed livenessProbe. It seems reasonable to allow users to also specify `periodSeconds` and `failureThreshold` for livenessProbe