### PR TITLE
feat(flipt, flipt-v2): support image.digest for tamper-resistant pinning

### DIFF
--- a/charts/flipt-v2/Chart.yaml
+++ b/charts/flipt-v2/Chart.yaml
@@ -5,7 +5,7 @@ description: >-
   Flipt v2 is a Git-native, open-source feature flag solution with enhanced
   authentication and multi-environment support.
 type: application
-version: 2.9.2
+version: 2.10.0
 appVersion: v2.9.0
 maintainers:
   - name: Flipt

--- a/charts/flipt-v2/Chart.yaml
+++ b/charts/flipt-v2/Chart.yaml
@@ -5,7 +5,7 @@ description: >-
   Flipt v2 is a Git-native, open-source feature flag solution with enhanced
   authentication and multi-environment support.
 type: application
-version: 2.10.0
+version: 2.9.3
 appVersion: v2.9.0
 maintainers:
   - name: Flipt

--- a/charts/flipt-v2/README.md
+++ b/charts/flipt-v2/README.md
@@ -76,6 +76,7 @@ flipt:
 | `replicaCount`        | int    | `1`                             | Number of replicas                                                                   |
 | `image.repository`    | string | `"docker.flipt.io/flipt/flipt"` | Image repository                                                                     |
 | `image.tag`           | string | `""`                            | Image tag (defaults to chart appVersion)                                             |
+| `image.digest`        | string | `""`                            | Optional image digest (e.g. `sha256:...`); appended to the image as `@digest`        |
 | `service.type`        | string | `"ClusterIP"`                   | Kubernetes service type                                                              |
 | `service.httpPort`    | int    | `8080`                          | HTTP service port                                                                    |
 | `service.grpcPort`    | int    | `9000`                          | gRPC service port                                                                    |

--- a/charts/flipt-v2/templates/deployment.yaml
+++ b/charts/flipt-v2/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{- with .Values.image.digest }}@{{ . }}{{- end }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
           {{- toYaml .Values.image.command | nindent 12 }}

--- a/charts/flipt-v2/templates/migration_job.yaml
+++ b/charts/flipt-v2/templates/migration_job.yaml
@@ -31,7 +31,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{- with .Values.image.digest }}@{{ . }}{{- end }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
           - "./flipt"

--- a/charts/flipt-v2/values.schema.json
+++ b/charts/flipt-v2/values.schema.json
@@ -180,6 +180,12 @@
           "description": "Overrides the image tag whose default is the chart appVersion.",
           "title": "tag",
           "type": "string"
+        },
+        "digest": {
+          "default": "",
+          "description": "Optional image digest (e.g. sha256:abc123...). When set, it is appended to the image reference as `@digest` so the OCI runtime resolves by digest.",
+          "title": "digest",
+          "type": "string"
         }
       },
       "title": "image",

--- a/charts/flipt-v2/values.yaml
+++ b/charts/flipt-v2/values.yaml
@@ -15,6 +15,9 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+  # Optional image digest (e.g. sha256:abc123...). When set, it is appended to
+  # the image reference as `@digest` so the OCI runtime resolves by digest.
+  digest: ""
   command: ["/flipt", "server"]
 
 imagePullSecrets: []

--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open-source, self-hosted feature flag solution.
 type: application
-version: 0.87.6
+version: 0.88.0
 appVersion: v1.61.1
 maintainers:
   - name: Flipt

--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open-source, self-hosted feature flag solution.
 type: application
-version: 0.88.0
+version: 0.87.7
 appVersion: v1.61.1
 maintainers:
   - name: Flipt

--- a/charts/flipt/README.md
+++ b/charts/flipt/README.md
@@ -98,6 +98,7 @@ You can also configure this chart using YAML. See the [values.yaml](https://gith
 | `replicaCount`        | int    | `1`                             | Number of replicas                                                       |
 | `image.repository`    | string | `"docker.flipt.io/flipt/flipt"` | Image repository                                                         |
 | `image.tag`           | string | `""`                            | Image tag (defaults to chart appVersion)                                 |
+| `image.digest`        | string | `""`                            | Optional image digest (e.g. `sha256:...`); appended to the image as `@digest` |
 | `service.type`        | string | `"ClusterIP"`                   | Kubernetes service type                                                  |
 | `service.httpPort`    | int    | `8080`                          | HTTP service port                                                        |
 | `service.grpcPort`    | int    | `9000`                          | gRPC service port                                                        |

--- a/charts/flipt/templates/deployment.yaml
+++ b/charts/flipt/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{- with .Values.image.digest }}@{{ . }}{{- end }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
           {{- toYaml .Values.image.command | nindent 12 }}

--- a/charts/flipt/templates/migration_job.yaml
+++ b/charts/flipt/templates/migration_job.yaml
@@ -31,7 +31,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{- with .Values.image.digest }}@{{ . }}{{- end }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
           - "./flipt"

--- a/charts/flipt/values.schema.json
+++ b/charts/flipt/values.schema.json
@@ -177,6 +177,12 @@
           "description": "Overrides the image tag whose default is the chart appVersion.",
           "title": "tag",
           "type": "string"
+        },
+        "digest": {
+          "default": "",
+          "description": "Optional image digest (e.g. sha256:abc123...). When set, it is appended to the image reference as `@digest` so the OCI runtime resolves by digest.",
+          "title": "digest",
+          "type": "string"
         }
       },
       "title": "image",

--- a/charts/flipt/values.yaml
+++ b/charts/flipt/values.yaml
@@ -6,6 +6,9 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+  # Optional image digest (e.g. sha256:abc123...). When set, it is appended to
+  # the image reference as `@digest` so the OCI runtime resolves by digest.
+  digest: ""
   command: ["/flipt"]
 
 imagePullSecrets: []


### PR DESCRIPTION
## Problem

Both `flipt` and `flipt-v2` render the container image as:

```yaml
image: \"{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}\"
```

so a `digest:` field added under `image:` in values is silently ignored. For `flipt-v2` the chart's JSON schema (`additionalProperties: false` on the image block) also rejects it outright.

The workaround today is to embed the digest into the tag:

```yaml
image:
  repository: docker.flipt.io/flipt/flipt
  tag: v2.8.0@sha256:921350bb9ef4deefa5dc16b8293f446d27c06742502eaf897a8276b12492078a
```

The OCI runtime honours the trailing `@sha256:` so it functions correctly, but it diverges from the convention every other widely-used chart uses, where `tag:` and `digest:` are separate fields.

## What this PR does

Adds an optional `image.digest` field to **both charts**. When set, it is appended to the rendered image reference as `@<digest>`:

```yaml
image:
  repository: docker.flipt.io/flipt/flipt
  tag: v2.9.0
  digest: sha256:921350bb9ef4deefa5dc16b8293f446d27c06742502eaf897a8276b12492078a
```

renders as `docker.flipt.io/flipt/flipt:v2.9.0@sha256:921350bb…`.

Behaviour with no digest set is unchanged.

## Changes per chart

- `templates/deployment.yaml` — append `@digest` to the image reference when set, via `{{- with .Values.image.digest }}@{{ . }}{{- end }}`.
- `templates/migration_job.yaml` — same (migration job runs the same image).
- `values.yaml` — add `digest: \"\"` with explanatory comment.
- `values.schema.json` — add `digest` to image properties (plus, in flipt-v2, this is needed to bypass `additionalProperties: false`).
- `Chart.yaml` — bump version (`flipt` 0.87.6 → 0.88.0, `flipt-v2` 2.9.2 → 2.10.0).
- `README.md` — document the new value.

## Verification

\`\`\`bash
helm template t charts/flipt-v2
# -> image: \"docker.flipt.io/flipt/flipt:v2.9.0\"   (unchanged)

helm template t charts/flipt-v2 --set image.digest=sha256:921350bb…
# -> image: \"docker.flipt.io/flipt/flipt:v2.9.0@sha256:921350bb…\"

helm template t charts/flipt-v2 --set image.tag=v2.8.0 --set image.digest=sha256:921350bb…
# -> image: \"docker.flipt.io/flipt/flipt:v2.8.0@sha256:921350bb…\"
\`\`\`

\`helm lint\` passes for both charts. CI \`ct lint\` + \`ct install\` should also pass — the change is additive and backward-compatible.

## Why this matters

Pinning by digest is the canonical defence against tag republishing (the same `v2.9.0` tag can be re-pushed to a different image at any time). With this PR, users can pin via the standard chart-author pattern instead of having to know about the embed-in-tag trick.