### PR TITLE
feat(flipt-v2): make test connection image repository configurable

### DIFF
--- a/charts/flipt-v2/Chart.yaml
+++ b/charts/flipt-v2/Chart.yaml
@@ -5,7 +5,7 @@ description: >-
   Flipt v2 is a Git-native, open-source feature flag solution with enhanced
   authentication and multi-environment support.
 type: application
-version: 2.11.0
+version: 2.11.1
 appVersion: v2.11.0
 maintainers:
   - name: Flipt

--- a/charts/flipt-v2/README.md
+++ b/charts/flipt-v2/README.md
@@ -86,6 +86,8 @@ flipt:
 | `autoscaling.enabled` | bool   | `false`                         | Enable horizontal pod autoscaling                                                    |
 | `flipt.config`        | object | `{}`                            | Flipt v2 configuration (see [docs](https://docs.flipt.io/v2/configuration/overview)) |
 | `flipt.extraEnvVars`  | array  | `[]`                            | Extra environment variables (must use FLIPT\_ prefix)                                |
+| `test.repository`     | string | `"busybox"`                     | Image repository for the `helm test` connection pod                                  |
+| `test.tag`            | string | `"latest"`                      | Image tag for the `helm test` connection pod                                         |
 
 ## Differences from Flipt v1
 

--- a/charts/flipt-v2/templates/tests/test-connection.yaml
+++ b/charts/flipt-v2/templates/tests/test-connection.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: busybox:{{ (.Values.test).tag | default "latest" }}
+      image: {{ (.Values.test).repository | default "busybox" }}:{{ (.Values.test).tag | default "latest" }}
       command: ['wget']
       args: ['{{ include "flipt-v2.fullname" . }}:{{ .Values.service.httpPort }}']
   restartPolicy: Never

--- a/charts/flipt-v2/values.schema.json
+++ b/charts/flipt-v2/values.schema.json
@@ -798,6 +798,10 @@
       "title": "test",
       "type": ["object", "null"],
       "properties": {
+        "repository": {
+          "default": "busybox",
+          "description": "the image repository to use for the test connection pod"
+        },
         "tag": {
           "default": "latest",
           "description": "the version of busybox to use"

--- a/charts/flipt-v2/values.yaml
+++ b/charts/flipt-v2/values.yaml
@@ -34,6 +34,9 @@ serviceAccount:
   name: ""
 
 test:
+  # Can override the image used by the test connection pod,
+  # e.g. to pull busybox from a private registry mirror
+  # repository: 'busybox'
   # Can pin the version of busybox to a specific version
   # tag: '1.36.1'
 


### PR DESCRIPTION
### Problem

The `helm test` connection pod in `charts/flipt-v2` hardcodes the `busybox` image repository:

```yaml
image: busybox:{{ (.Values.test).tag | default "latest" }}
```

Only the tag is configurable. In clusters that can only pull from a private registry or a pull-through mirror (air-gapped, or with an admission policy restricting registries), `helm test` fails on image pull even though the release itself is healthy.

### Change

Add an optional `test.repository`, defaulting to `busybox`:

```yaml
image: {{ (.Values.test).repository | default "busybox" }}:{{ (.Values.test).tag | default "latest" }}
```

Defaults are unchanged, so existing users — including those already setting `test.tag` — are unaffected.

- `templates/tests/test-connection.yaml`: use `test.repository`
- `values.yaml`: document the new value alongside the existing `tag`
- `values.schema.json`: add `test.repository` (the `test` block is `additionalProperties: false`, so it would otherwise be rejected)
- `Chart.yaml`: bump chart version 2.11.0 -> 2.11.1
- `README.md`: document `test.repository` and `test.tag`

### Verification

`helm template` output:

- defaults → `busybox:latest` (unchanged)
- `--set test.repository=my.registry/busybox --set test.tag=1.36.1` → `my.registry/busybox:1.36.1`

`helm lint charts/flipt-v2` passes.

### Note

`charts/flipt` (v1) has the identical hardcoding. I kept this PR to v2 to stay minimal — happy to include v1 in the same PR if you'd prefer them consistent.