### PR TITLE
feat(flipt-v2): add startupProbe and initContainers support

### DIFF
--- a/charts/flipt-v2/Chart.yaml
+++ b/charts/flipt-v2/Chart.yaml
@@ -5,7 +5,7 @@ description: >-
   Flipt v2 is a Git-native, open-source feature flag solution with enhanced
   authentication and multi-environment support.
 type: application
-version: 2.11.1
+version: 2.11.2
 appVersion: v2.11.0
 maintainers:
   - name: Flipt

--- a/charts/flipt-v2/README.md
+++ b/charts/flipt-v2/README.md
@@ -86,6 +86,8 @@ flipt:
 | `autoscaling.enabled` | bool   | `false`                         | Enable horizontal pod autoscaling                                                    |
 | `flipt.config`        | object | `{}`                            | Flipt v2 configuration (see [docs](https://docs.flipt.io/v2/configuration/overview)) |
 | `flipt.extraEnvVars`  | array  | `[]`                            | Extra environment variables (must use FLIPT\_ prefix)                                |
+| `initContainers`      | array  | `[]`                            | Init containers run to completion before the flipt container starts                  |
+| `startupProbe`        | object | `{}`                            | Startup probe; suspends liveness until started, protecting a slow first boot         |
 | `test.repository`     | string | `"busybox"`                     | Image repository for the `helm test` connection pod                                  |
 | `test.tag`            | string | `"latest"`                      | Image tag for the `helm test` connection pod                                         |
 

--- a/charts/flipt-v2/templates/deployment.yaml
+++ b/charts/flipt-v2/templates/deployment.yaml
@@ -49,6 +49,10 @@ spec:
       serviceAccountName: {{ include "flipt-v2.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -108,6 +112,10 @@ spec:
             {{- if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/charts/flipt-v2/values.schema.json
+++ b/charts/flipt-v2/values.schema.json
@@ -853,6 +853,20 @@
           "type": "string"
         }
       }
+    },
+    "initContainers": {
+      "description": "initContainers is a list of init containers that run to completion before the flipt container starts. Values are templated.",
+      "items": {},
+      "title": "initContainers",
+      "type": "array",
+      "default": []
+    },
+    "startupProbe": {
+      "additionalProperties": true,
+      "description": "startupProbe suspends the liveness probe until the container has started, so a slow first boot is not killed midway. Disabled when empty.",
+      "title": "startupProbe",
+      "type": "object",
+      "default": {}
     }
   },
   "type": "object"

--- a/charts/flipt-v2/values.yaml
+++ b/charts/flipt-v2/values.yaml
@@ -66,6 +66,32 @@ securityContext:
   seccompProfile:
     type: "RuntimeDefault"
 
+## initContainers run to completion before the flipt container starts. Useful for any
+## preparation flipt cannot do for itself, for example:
+##   - validating or repairing a persisted git clone before flipt tries to read it
+##   - refreshing SSH known_hosts, so a host key rotation upstream does not block
+##     every replica from starting
+##   - seeding the data volume from a backup, or correcting its ownership
+##   - waiting on a dependency to become reachable
+## Values here are templated, so they may reference other values.
+##
+initContainers: []
+
+## startupProbe gives a slow-starting instance time to come up before the liveness
+## probe is allowed to act. While it is running the liveness probe is suspended, so
+## a lengthy first-boot (e.g. cloning a large git repository over a slow link) cannot
+## be killed midway. Disabled by default; when unset, liveness applies from the start.
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+##
+## startupProbe:
+##   httpGet:
+##     path: /health
+##     port: http
+##   periodSeconds: 10
+##   failureThreshold: 30
+##
+startupProbe: {}
+
 readinessProbe:
   httpGet:
     path: /health


### PR DESCRIPTION
 The chart currently has no way to set a `startupProbe` or `initContainers`...

  ## startupProbe

  Flipt initializes the environment store (git clone/fetch) before the HTTP server binds. In
  `internal/cmd/grpc.go`, `environments.NewStore()` is called during server construction, and the
  HTTP server only starts once that returns. Until then nothing is listening on the http port and
  probes get `connection refused`.

  Chart default:
  
  ```yaml
  livenessProbe:
    httpGet: { path: /health, port: http }
    initialDelaySeconds: 3
  ```

  `initialDelaySeconds: 3` plus `periodSeconds: 10` x `failureThreshold: 3` restarts the container
  about 33s after start. Any clone slower than that is SIGKILLed partway through and the pod ends
  up in CrashLoopBackOff. A large flag repo, a slow link, or a remote that is briefly unreachable
  all hit this.

  The only workaround today is raising `livenessProbe.initialDelaySeconds`, which applies for the                                       
  whole life of the pod rather than just startup. A `startupProbe` is scoped to startup: liveness
  is suspended while it runs and takes over once it passes.

  With `persistence.enabled: true` the SIGKILL can also leave a partially written git repo on the
  PVC, and that survives the restart.

  ## initContainers

  There is no hook for work that has to happen before flipt starts. Cases:

  - validate or repair a persisted git clone
  - refresh SSH `known_hosts` (a pinned `ssh.knownHosts` stops every replica starting when the
    upstream host key rotates)
  - seed the data volume from a backup, or fix its ownership
  - wait for the git remote to be reachable

  Rendered through `common.tplvalues.render`, same as `flipt.extraEnvVars`, so entries can
  reference other values.

  ## Changes

  - `templates/deployment.yaml`: render `initContainers` and `startupProbe`, both `with`-guarded
  - `values.yaml`: `initContainers: []`, `startupProbe: {}`
  - `values.schema.json`: entries for both keys
  - `README.md`: two rows in the values table
  - `Chart.yaml`: 2.11.1 -> 2.12.0

  Both default to empty and render nothing, so output is unchanged for existing installs.

## Testing

  Rendering:

  - `helm lint` passes
  - default values: neither key appears in the rendered output
  - both set: `startupProbe` renders before `livenessProbe`, `initContainers` templating resolves
  - `kubectl apply --dry-run=client` accepts the rendered StatefulSet
  - `values.schema.json` valid, schema validation passes with both keys set
  
  In-cluster (EKS 1.35). Chart installed twice into one namespace with identical values apart from
  the two new keys, using `kind: Deployment` and `persistence.enabled: false` so `flipt-data` is an
  emptyDir. Both releases override `image.command` with `sleep 60; exec /flipt server` to simulate
  an initial clone slower than the ~33s the default liveness probe allows:

  ```
          control (no startupProbe)     treatment (startupProbe)
  t=60s   0/1 Running  restarts:0       0/1 Running  restarts:0
  t=80s   0/1 Running  restarts:1       0/1 Running  restarts:0
  t=90s   0/1 Running  restarts:1       1/1 Running  restarts:0
  t=130s  0/1 Running  restarts:2       1/1 Running  restarts:0
  t=190s  0/1 Running  restarts:3       1/1 Running  restarts:0
  ```

  Control never reaches Ready. It is killed roughly every 55s and cannot finish a start that needs
  60s:

  ```
  Warning  Unhealthy  Liveness probe failed: dial tcp ...:8080: connect: connection refused
  Normal   Killing    Container flipt-v2 failed liveness probe, will be restarted
  ```

  Treatment reaches Ready at t=90s with 0 restarts, and logs no `Killing` or `Liveness probe failed`                                    
  event at any point in its life. `/health` returns `{"status":"SERVING"}`.

  initContainer in the treatment release:

  - terminated with `exitCode=0 reason=Completed`
  - templating resolved: wrote `init-ran-for-trt` from `{{ .Release.Name }}`
  - the flipt container reads that file back from the shared `flipt-data` volume

  ## Example

  ```yaml
  persistence:
    enabled: true

  startupProbe:
    httpGet:
      path: /health
      port: http
    periodSeconds: 10
    failureThreshold: 30   # up to 5m for the initial clone
  
  initContainers:
    - name: prepare-data
      image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
      command: ["/bin/sh", "-c", "..."]
      volumeMounts:
        - name: flipt-data
          mountPath: /var/opt/flipt
  ```