### PR TITLE
ci: inline Flipt config schemas into chart values during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,44 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Chart appVersion
+        id: chart
+        run: |
+          APPVERSIONV1=$(grep '^appVersion:' charts/flipt/Chart.yaml | awk '{print $2}' | tr -d '"'"'"'')
+          APPVERSIONV2=$(grep '^appVersion:' charts/flipt-v2/Chart.yaml | awk '{print $2}' | tr -d '"'"'"'')
+
+          if ! [[ "$APPVERSIONV1" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::appVersion::v1 '$APPVERSIONV1' doesn't look like a valid version (expected vX.Y.Z)"
+            exit 1
+          fi
+          if ! [[ "$APPVERSIONV2" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::appVersion::v2 '$APPVERSIONV2' doesn't look like a valid version (expected vX.Y.Z)"
+            exit 1
+          fi
+
+          echo "Resolved appVersion V1: $APPVERSIONV1"
+          echo "Resolved appVersion V2: $APPVERSIONV2"
+
+          echo "appVersionV1=$APPVERSIONV1" >> "$GITHUB_OUTPUT"
+          echo "appVersionV2=$APPVERSIONV2" >> "$GITHUB_OUTPUT"
+
+      - name: Inline Flipt config schema
+        run: |
+          V1_SCHEMA_URL="https://raw.githubusercontent.com/flipt-io/flipt/refs/tags/${{ steps.chart.outputs.appVersionV1 }}/config/flipt.schema.json"
+          V2_SCHEMA_URL="https://raw.githubusercontent.com/flipt-io/flipt/refs/tags/${{ steps.chart.outputs.appVersionV2 }}/config/flipt.schema.json"
+
+          curl -sL --fail "$V1_SCHEMA_URL" -o /tmp/fliptV1.schema.json
+          curl -sL --fail "$V2_SCHEMA_URL" -o /tmp/fliptV2.schema.json
+
+          jq --slurpfile schema /tmp/fliptV1.schema.json '.properties.flipt.properties.config = $schema[0]' \
+            charts/flipt/values.schema.json > charts/flipt/values.schema.json.tmp
+
+          mv charts/flipt/values.schema.json.tmp charts/flipt/values.schema.json
+
+          jq --slurpfile schema /tmp/fliptV2.schema.json '.properties.flipt.properties.config = $schema[0]' \
+            charts/flipt-v2/values.schema.json > charts/flipt-v2/values.schema.json.tmp
+
+          mv charts/flipt-v2/values.schema.json.tmp charts/flipt-v2/values.schema.json
 
       - name: Install Helm
         uses: azure/setup-helm@v4

--- a/charts/flipt-v2/Chart.yaml
+++ b/charts/flipt-v2/Chart.yaml
@@ -5,7 +5,7 @@ description: >-
   Flipt v2 is a Git-native, open-source feature flag solution with enhanced
   authentication and multi-environment support.
 type: application
-version: 2.12.0
+version: 2.12.1
 appVersion: v2.12.0
 maintainers:
   - name: Flipt

--- a/charts/flipt-v2/values.schema.json
+++ b/charts/flipt-v2/values.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "additionalProperties": true,
   "properties": {
     "affinity": {

--- a/charts/flipt/Chart.yaml
+++ b/charts/flipt/Chart.yaml
@@ -3,7 +3,7 @@ name: flipt
 home: https://flipt.io
 description: Flipt is an open-source, self-hosted feature flag solution.
 type: application
-version: 0.87.7
+version: 0.87.8
 appVersion: v1.61.1
 maintainers:
   - name: Flipt

--- a/charts/flipt/values.schema.json
+++ b/charts/flipt/values.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "additionalProperties": true,
   "properties": {
     "affinity": {


### PR DESCRIPTION
Add a release workflow step that fetches the corresponding Flipt config schema JSON from the upstream repo at the pinned appVersion tag, then inlines it into each chart's values.schema.json.

closes #281, #291